### PR TITLE
fix testConnectedComponents

### DIFF
--- a/test/src/edu/stanford/nlp/graph/DirectedMultiGraphTest.java
+++ b/test/src/edu/stanford/nlp/graph/DirectedMultiGraphTest.java
@@ -158,8 +158,21 @@ public class DirectedMultiGraphTest extends TestCase {
       System.out.println("Connected component: " + cc);
     }
     assertEquals(ccs.size(), 4);
-    assertEquals(CollectionUtils.sorted(ccs.get(0)),
-                 Arrays.asList(1, 2, 3, 4));
+    
+    Set<Set<Integer>> s = new HashSet<>();
+    Set<Integer> tmp = new HashSet<>(Arrays.asList(8));
+    s.add(tmp);
+    tmp = new HashSet<>(Arrays.asList(1,2,3,4));
+    s.add(tmp);
+    tmp = new HashSet<>(Arrays.asList(5,6,7));
+    s.add(tmp);
+    tmp = new HashSet<>(Arrays.asList(9,10));
+    s.add(tmp);
+
+    for (Set<Integer> cc : ccs){
+        assertTrue(s.contains(cc));
+    }
+
   }
 
   public void testEdgesNodes() {


### PR DESCRIPTION
`testConnectedComponents` checks the connected components results of `graph.getConnectedComponents()`, which returns a `List<Set<Integer>>`: each set is a connected component and they are pushed into a list in **random** order. 

The original code `assertEquals(CollectionUtils.sorted(ccs.get(0)), Arrays.asList(1, 2, 3, 4));` gets the first element in the list and sorts in ascending order, but the first element is not deterministic. We have to check if each connected component equals to the corresponding expected CC, since we can not sort a list of sets.  We can not directly compare whether two nested sets are equal using `assertEqual` either because comparator with set is not defined and the default comparator is by reference. 